### PR TITLE
Added header and footer locators. Fixed flaky tests with menu button.

### DIFF
--- a/src/locators/header_footer_locators.py
+++ b/src/locators/header_footer_locators.py
@@ -1,0 +1,60 @@
+"""This models the header and footer objects that most pages contain. Note: this is not an actual page!
+
+"""
+
+from selenium.webdriver.common.by import By
+
+
+class HeaderFooterLocators(object):
+    """This class contains the Locators for the header and footer objects. These are tuples containing both how to
+    locate the element and the actual locator string.
+
+    The first index should use members belonging to Selenium's "By" class.
+        Ex: By.ID, By.XPATH, By.CSS, etc.
+
+    The second index is the actual locator string (based off the first index above).
+
+    """
+
+    # Header Links
+    LOGO_HEADER = (By.XPATH, "//h1[@class='h1_logo']/a")
+    PHONE_NUMBER_HEADER = (By.XPATH, "//a[@class='phone']")
+    HOW_IT_WORKS_HEADER = (By.XPATH, "//*[@class='option how']/a")
+    TESTIMONIALS_HEADER = (By.XPATH, "//li[@class='option testimonials']/a")
+    PRICING_HEADER = (By.XPATH, "//li[@class='option pricing']/a")
+    REQUEST_DEMO_HEADER = (By.XPATH, "//li[@class='demo']/a")
+    NAV_MENU_HEADER = (By.XPATH, "//p/a[@href='#']")
+
+    # Nav Menu Links
+    NAV_MENU = (By.XPATH, "//div[@class='nav__menu']")
+    NAV_MENU_CLOSE_BUTTON = (By.XPATH, "//div[@class='nav__menu__close common-close']/a")
+    HOW_IT_WORKS_NAV = (By.XPATH, "//ul[@class='main']/li[1]/a")
+    TESTIMONIALS_NAV = (By.XPATH, "//ul[@class='main']/li[2]/a")
+    PRICING_NAV = (By.XPATH, "//ul[@class='main']/li[3]/a")
+    REQUEST_DEMO_NAV = (By.XPATH, "//ul[@class='main']/li[4]/a")
+    FLEX_DELIVERY_NAV = (By.XPATH, "//ul[@class='sub']/li[1]/a")
+    MARKETING_NAV = (By.XPATH, "//ul[@class='sub']/li[2]/a")
+    WEBSITES_NAV = (By.XPATH, "//ul[@class='sub']/li[3]/a")
+    ABOUT_US_NAV = (By.XPATH, "//ul[@class='sub']/li[4]/a")
+    CAREERS_NAV = (By.XPATH, "//ul[@class='sub']/li[5]/a")
+    BLOG_NAV = (By.XPATH, "//ul[@class='sub']/li[6]/a")
+    CONTACT_NAV = (By.XPATH, "//ul[@class='sub']/li[6]/a")
+    REFUND_POLICY_NAV = (By.XPATH, "//ul[@class='extras']/li[1]/a")
+    TERMS_OF_SERVICE_NAV = (By.XPATH, "//ul[@class='extras']/li[2]/a")
+    PRIVATE_POLICY_NAV = (By.XPATH, "//ul[@class='extras']/li[3]/a")
+
+    # Footer Links
+    LOGO_FOOTER = (By.XPATH, "//div[@class='footer__group left logo']/a")
+    HOW_IT_WORKS_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[1]")
+    TESTIMONIALS_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[2]")
+    PRICING_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[3]")
+    BLOG_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[4]")
+    MARKETING_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[5]")
+    FLEX_DELIVERY_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[6]")
+    WEBSITES_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[7]")
+    ABOUT_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[8]")
+    CAREERS_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[9]")
+    CONTACT_US_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[10]")
+    REFUND_POLICY_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[11]")
+    TERMS_OF_SERVICE_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[12]")
+    PRIVATE_POLICY_FOOTER = (By.XPATH, "(//ul[@class='menu']/li/a)[13]")

--- a/src/pages/base_page.py
+++ b/src/pages/base_page.py
@@ -2,35 +2,35 @@
 
 """
 
+from selenium.webdriver.common.by import By
+
 
 class BasePage(object):
     BASE_URL = "https://www.chownow.com/"
-    PAGE_TITLE = ""
 
     def __init__(self, driver):
         self.driver = driver
 
-    def go_to(self, url):
+    def go_to(self):
         """Opens up the URL. When called from a child class, the child's class url will be used instead.
 
-        :param url: (Str) The desired URL to open.
         :return: None
         """
-        self.driver.get(self.get_page_url())
+        self.driver.get(self.BASE_URL)
 
     def get_page_url(self):
         """Gets the URL of the home page. When called from a child class, the child's class url will be used instead.
 
         :return: (Str) The home page url.
         """
-        return self.BASE_URL
+        return self.driver.url
 
     def get_page_title(self):
         """Gets the title of the home page. When called from a child class, the child's class title will be used instead.
 
         :return: (Str) The title of the home page.
         """
-        return self.PAGE_TITLE
+        return self.driver.title
 
     def get_element(self, locator):
         """This helper method will return a web element. Be sure to use Selenium's "By" class.
@@ -59,3 +59,13 @@ class BasePage(object):
         """
         web_element.clear()
         web_element.send_keys(text)
+
+    def _remove_swipe_element(self):
+        """A web element was added to the right side of the pages that have the menu nav button (for touch screen swiping).
+        This method will make this element invisible so we can click on the menu nav button (overlaps with this bar).
+
+        :return:
+        """
+        SWIPE_BAR = (By.CLASS_NAME, "swipe")
+        if self.get_element(SWIPE_BAR).is_displayed():
+            self.driver.execute_script("document.getElementsByClassName('swipe')[0].style.visibility = 'hidden';")

--- a/src/pages/demo_page.py
+++ b/src/pages/demo_page.py
@@ -2,8 +2,12 @@
 
 """
 
-from src.pages.base_page import BasePage
 from selenium.webdriver.common.by import By
+
+from src.pages.base_page import BasePage
+
+
+# TODO: Looks like the request demo text fields are on multiple pages: home, how it works, pricing, websites
 
 
 class DemoPage(BasePage):
@@ -30,13 +34,6 @@ class DemoPage(BasePage):
         FIELD_ERROR_MESSAGE = (By.XPATH, "//p[contains(text(), 'Oops.')]")
         CLOSE_FIELD_ERROR_MESSAGE_BUTTON = (By.XPATH, "//div[@class='error__close common-close']/a")
         WHY_ARE_YOU_MOST_INTERESTED_COMBO_BOX = (By.XPATH, "//select[@id='Why_Interested_in_Online_Ordering__c']")
-
-    def go_to(self):
-        """This method gets us the demo page
-
-        :return: None.
-        """
-        super(DemoPage, self).go_to(self.get_page_url())
 
     # ==================================================================================================================
     # Clicks

--- a/src/pages/home_page.py
+++ b/src/pages/home_page.py
@@ -11,14 +11,16 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
 
+from src.locators.header_footer_locators import HeaderFooterLocators
 from src.pages.base_page import BasePage
 
 
 class HomePage(BasePage):
     BASE_URL = "https://www.chownow.com/"
     PAGE_TITLE = "Online Food Ordering System & App - ChowNow"
+    TIMEOUT = 5
 
-    class Locators(object):
+    class Locators(HeaderFooterLocators):
         """This class contains the Locators for the home page. These are tuples containing both how to locate the element
         and the actual locator string.
 
@@ -28,28 +30,17 @@ class HomePage(BasePage):
         The second index is the actual locator string (based off the first index above).
 
         """
-        NAV_MENU_BUTTON = (By.XPATH, "//p/a[@href='#']")
-        NAV_MENU_CLOSE_BUTTON = (By.XPATH, "//div[@class='nav__menu__close common-close']/a")
-        NAV_MENU = (By.XPATH, "//div[@class='nav__menu']")
-        MAIN_LOGO = (By.XPATH, "//h1[@class='h1_logo']/a")
-        HOW_IT_WORKS_BUTTON = (By.XPATH, "//*[@class='option how']/a")
-        REQUEST_DEMO_BUTTON = (By.XPATH, "//li[@class='demo']/a")
         CLOSE_GREEN_NOTIFICATION_BAR = (By.XPATH, "//*[@class='header__notification__close']/a")
 
-    # TODO: This assumes that we will visit the home page once during a test. If the green bar is not there, error!
     def go_to(self):
         """This method gets us to the home page.
-
-        NOTE: There is a green drop down message when visiting the home page for the first time. This will interfere
-        with our tests, so this method will find it and close it before proceeding.
 
         :return: None.
         """
 
-        super(HomePage, self).go_to(self.get_page_url())
-        wait = WebDriverWait(self.driver, 5)
-        wait.until(expected_conditions.visibility_of_element_located(self.Locators.CLOSE_GREEN_NOTIFICATION_BAR))
-        self.click_on(self.get_element(self.Locators.CLOSE_GREEN_NOTIFICATION_BAR))
+        self.driver.get(self.BASE_URL)
+        self.close_header_notification()
+        self._remove_swipe_element()
 
     def click_main_logo(self):
         """This method will click on the ChowNow logo on the top left of the nav bar.
@@ -57,7 +48,7 @@ class HomePage(BasePage):
         :return: None.
         """
 
-        self.click_on(self.get_element(self.Locators.MAIN_LOGO))
+        self.click_on(self.get_element(self.Locators.LOGO_HEADER))
 
     def click_how_it_works_button(self):
         """This method will click on the "how it works" link on the home page.
@@ -65,7 +56,7 @@ class HomePage(BasePage):
         :return: None.
         """
 
-        self.click_on(self.get_element(self.Locators.HOW_IT_WORKS_BUTTON))
+        self.click_on(self.get_element(self.Locators.HOW_IT_WORKS_HEADER))
 
     def click_nav_menu_button(self):
         """ This method will click on the menu (hamburger or stack) icon, which opens a context menu.
@@ -73,7 +64,7 @@ class HomePage(BasePage):
         :return: None.
         """
 
-        self.click_on(self.get_element(self.Locators.NAV_MENU_BUTTON))
+        self.click_on(self.get_element(self.Locators.NAV_MENU_HEADER))
 
     def click_nav_menu_close_button(self):
         """ This method will click on the menu close icon (X), which closes the context menu.
@@ -88,4 +79,18 @@ class HomePage(BasePage):
 
         :return: None.
         """
-        self.click_on(self.get_element(self.Locators.REQUEST_DEMO_BUTTON))
+        self.click_on(self.get_element(self.Locators.REQUEST_DEMO_HEADER))
+
+    def close_header_notification(self):
+        """This method closes the green notification bar that pops up when visiting the home page.
+
+        This bar will causes issues when trying to click on elements on the home page.
+        NOTE: This should get called when visiting the home page (even from another page).
+
+        :return: None.
+        """
+        wait = WebDriverWait(self.driver, self.TIMEOUT)
+        wait.until(expected_conditions.visibility_of_element_located(self.Locators.CLOSE_GREEN_NOTIFICATION_BAR))
+
+        if self.get_element(self.Locators.CLOSE_GREEN_NOTIFICATION_BAR).is_displayed():
+            self.click_on(self.get_element(self.Locators.CLOSE_GREEN_NOTIFICATION_BAR))

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -8,6 +8,7 @@
 
 import pytest
 from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
@@ -25,7 +26,13 @@ def chrome_driver():
     :return: Chrome web driver object.
     """
 
-    return webdriver.Chrome()
+    # TODO: Be able to pass something into the pytest command
+    # Option to run headless!
+    chrome_options = Options()
+    # chrome_options.add_argument("--headless")
+    # chrome_options.add_argument("--window-size=1920x1080")
+
+    return webdriver.Chrome(chrome_options=chrome_options)
 
 
 @pytest.fixture


### PR DESCRIPTION
- The header and footer locators will be used by other pages so we can
avoid duplicate code.
- Removed blank "title" attribute from base class (no need for it).
- Base class returns actual url and title instead of the defined
attributes up top.
- Added a helper method to hide the new "swipe" element which was
causing tests that clicked on the menu button to flake.
- Removed call to super in demo page. It will now inherit the go_to
from the base page.
- Removed duplicate locators from home page, which are now found in the
new header and footer locator class. Refactored pages accordingly.
- Added code to run tests in headless mode. Will create a new branch
to allow us to enable this via command line arg.